### PR TITLE
Ducks other audio when playing example sentence 

### DIFF
--- a/ios/Tables/ContextSentenceTTS/TTSAudioManager.swift
+++ b/ios/Tables/ContextSentenceTTS/TTSAudioManager.swift
@@ -47,6 +47,8 @@ class TTSAudioManager: NSObject {
     }
 
     avPlayer.seek(to: CMTime(seconds: 0, preferredTimescale: 1))
+
+    deactivateSessionAudio()
   }
 
   func retrieveAudio(for text: String) async throws -> TranslatedVoiceData? {
@@ -128,6 +130,15 @@ class TTSAudioManager: NSObject {
       try audioSession.setCategory(.playback, options: .duckOthers)
     } catch {
       print("Failed to set the audio session configuration")
+    }
+  }
+
+  func deactivateSessionAudio() {
+    let session = AVAudioSession.sharedInstance()
+    do {
+      try session.setActive(false, options: .notifyOthersOnDeactivation)
+    } catch {
+      print("Failed to deactivate audio session: \(error.localizedDescription)")
     }
   }
 

--- a/ios/Tables/ContextSentenceTTS/TTSAudioManager.swift
+++ b/ios/Tables/ContextSentenceTTS/TTSAudioManager.swift
@@ -104,6 +104,8 @@ class TTSAudioManager: NSObject {
     let fileName = data.URL.absoluteString
     docsURL.appendPathComponent(fileName)
 
+    configureAudioSession()
+
     let asset = AVURLAsset(url: docsURL)
     let playerItem = AVPlayerItem(asset: asset)
 
@@ -116,6 +118,16 @@ class TTSAudioManager: NSObject {
     // Reset debounce flag after short delay
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
       self.isStartingPlayback = false
+    }
+  }
+
+  func configureAudioSession() {
+    let audioSession = AVAudioSession.sharedInstance()
+    do {
+      // Set the audio session category and mode.
+      try audioSession.setCategory(.playback, options: .duckOthers)
+    } catch {
+      print("Failed to set the audio session configuration")
     }
   }
 


### PR DESCRIPTION
While listening to other music, for example, this is helpful to ensure clear listening of the example sentence.

Includes code to automatically duck other audio, and have the audio unducked if interrupted (by hitting the stop button)